### PR TITLE
Replace Resin base image with Balena.

### DIFF
--- a/arm32v7-crossbuild/Dockerfile
+++ b/arm32v7-crossbuild/Dockerfile
@@ -1,12 +1,14 @@
 # Dockerfile that will build an arm32v7 image on an x86 build host
 
-FROM resin/raspberrypi3-node:6
-# Resin base image required for cross-build capabilities
+FROM balenalib/raspberrypi3-debian-node:6
+# Balena base image required for cross-build capabilities
 
 WORKDIR /app
 
 ### Run commands within QEMU ARM cross-build emulation
 RUN [ "cross-build-start" ]
+
+RUN install_packages curl
 
 RUN adduser --disabled-password --gecos "" node
 


### PR DESCRIPTION
Balena introduced an accidental breaking change for cross-builds in their deprecation message for the Resin images. Curl also appears to be absent in the new base image.

This commit switches to using the new Balena images.