### PR TITLE
Update to use a deep healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ EXPOSE 5005
 USER node
 
 HEALTHCHECK --interval=1m --timeout=2s \
-  CMD curl -LSs http://localhost:5005 || exit 1
+  CMD curl -LSfs http://localhost:5005/zones || exit 1
 
 CMD npm start


### PR DESCRIPTION
Update to use a deep healthcheck since / will return 200 even when the connection to sonos is unavailable.  

I kept having to restart my container for transient network failures because the healthcheck wasn't working properly.  

Changing it to call /zones instead will return an error and allow the healthcheck to work as intended.

Tested on my raspberrypi:
1. With current healthcheck:
```bash
pi@raspberrypi:~ $ curl -LSs http://localhost:5005
<!DOCTYPE html>
<html>
  <head>
...
</html>
* Connection #0 to host localhost left intact
pi@raspberrypi:~ $ echo $?
0
```
2. With healthcheck proposed in this PR (I forgot the `SsL` modifiers, but it works):
```bash
pi@raspberrypi:~ $ curl -f -vvv http://localhost:5005/zones
* Expire in 0 ms for 6 (transfer 0x13e38b0)
...
* The requested URL returned error: 500 Internal Server Error
* Closing connection 0
curl: (22) The requested URL returned error: 500 Internal Server Error
pi@raspberrypi:~ $ echo $?
22
```
